### PR TITLE
Implement gh-upload-image: upload images to GitHub CDN

### DIFF
--- a/.changeset/gh-upload-image-initial.md
+++ b/.changeset/gh-upload-image-initial.md
@@ -1,0 +1,14 @@
+---
+'gh-upload-image': minor
+---
+
+Initial implementation of gh-upload-image - a CLI and library for uploading images to GitHub
+
+Features:
+
+- Upload images to GitHub's CDN using the undocumented /upload/policies/assets endpoint
+- CLI tool with markdown output support
+- Library with full TypeScript definitions
+- Support for images (PNG, JPG, GIF, WebP, SVG), videos (MP4, MOV), documents (PDF, DOCX, TXT), and archives (ZIP, GZ)
+- Uses GitHub CLI (gh) for authentication
+- Multi-runtime support (Node.js, Bun, Deno)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/gh-upload-image/issues/1
-Your prepared branch: issue-1-4aad21db491b
-Your prepared working directory: /tmp/gh-issue-solver-1767093860934
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/gh-upload-image/issues/1
+Your prepared branch: issue-1-4aad21db491b
+Your prepared working directory: /tmp/gh-issue-solver-1767093860934
+
+Proceed.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,9 @@ export default [
         __filename: 'readonly',
         // Node.js 18+ globals
         fetch: 'readonly',
+        FormData: 'readonly',
+        Blob: 'readonly',
+        URLSearchParams: 'readonly',
         // Runtime-specific globals
         Bun: 'readonly',
         Deno: 'readonly',

--- a/examples/basic-usage.js
+++ b/examples/basic-usage.js
@@ -1,27 +1,92 @@
 /**
- * Basic usage example
- * Demonstrates how to use the package
+ * Basic usage example for gh-upload-image
+ *
+ * This example demonstrates how to use the library to upload images to GitHub.
  *
  * Run with any runtime:
  * - Bun: bun examples/basic-usage.js
  * - Node.js: node examples/basic-usage.js
- * - Deno: deno run examples/basic-usage.js
+ * - Deno: deno run --allow-read --allow-net --allow-run examples/basic-usage.js
  */
 
-import { add, multiply, delay } from '../src/index.js';
+import {
+  generateMarkdown,
+  formatFileSize,
+  isExtensionAllowed,
+  parseRepository,
+  ALLOWED_EXTENSIONS,
+} from '../src/index.js';
 
-// Example: Using add function
-console.log('Addition examples:');
-console.log(`  2 + 3 = ${add(2, 3)}`);
-console.log(`  -1 + 5 = ${add(-1, 5)}`);
+// Example 1: Check allowed extensions
+console.log('Allowed file extensions:');
+console.log(`  ${ALLOWED_EXTENSIONS.join(', ')}`);
+console.log('');
 
-// Example: Using multiply function
-console.log('\nMultiplication examples:');
-console.log(`  4 * 5 = ${multiply(4, 5)}`);
-console.log(`  -2 * 3 = ${multiply(-2, 3)}`);
+// Example 2: Parse repository formats
+console.log('Repository parsing examples:');
 
-// Example: Using async delay function
-console.log('\nAsync example:');
-console.log('  Waiting 100ms...');
-await delay(100);
-console.log('  Done!');
+const formats = [
+  'owner/repo',
+  'https://github.com/owner/repo',
+  'git@github.com:owner/repo.git',
+];
+
+for (const format of formats) {
+  const parsed = parseRepository(format);
+  console.log(`  "${format}"`);
+  console.log(`    -> owner: ${parsed.owner}, repo: ${parsed.repo}`);
+}
+console.log('');
+
+// Example 3: Check file extension
+console.log('Extension validation:');
+const testFiles = ['image.png', 'photo.jpg', 'script.js', 'document.pdf'];
+for (const file of testFiles) {
+  const allowed = isExtensionAllowed(file);
+  console.log(`  ${file}: ${allowed ? 'allowed' : 'not allowed'}`);
+}
+console.log('');
+
+// Example 4: Format file sizes
+console.log('File size formatting:');
+const sizes = [0, 500, 1024, 1024 * 1024, 1024 * 1024 * 1024];
+for (const size of sizes) {
+  console.log(`  ${size} bytes -> ${formatFileSize(size)}`);
+}
+console.log('');
+
+// Example 5: Generate markdown (using mock result)
+console.log('Markdown generation:');
+const mockResult = {
+  url: 'https://github.com/user-attachments/assets/example-id',
+  fileName: 'screenshot.png',
+};
+console.log(`  Default: ${generateMarkdown(mockResult)}`);
+console.log(`  With alt: ${generateMarkdown(mockResult, 'My Screenshot')}`);
+console.log('');
+
+// Example 6: Upload image (dry mode - no actual upload)
+console.log('Dry mode upload example:');
+console.log('  Note: This requires a valid image file and repository.');
+console.log('  To test, run with: --dry-mode flag');
+console.log('');
+
+// To test actual upload, use the CLI or import uploadImage:
+// import { uploadImage } from '../src/index.js';
+//
+// const result = await uploadImage({
+//   filePath: './test-image.png',
+//   repository: 'owner/repo',
+//   verbose: true,
+//   dryMode: true, // Set to false for actual upload
+// });
+//
+// console.log('Upload result:');
+// console.log(`  URL: ${result.url}`);
+// console.log(`  File: ${result.fileName}`);
+// console.log(`  Size: ${formatFileSize(result.fileSize)}`);
+//
+// const markdown = generateMarkdown(result, 'Test Image');
+// console.log(`  Markdown: ${markdown}`);
+
+console.log('Done!');

--- a/experiments/test-upload.js
+++ b/experiments/test-upload.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+/**
+ * Test script for uploading an image to GitHub
+ *
+ * This creates a simple test PNG and uploads it to the gh-upload-image repository.
+ *
+ * Usage: node experiments/test-upload.js
+ */
+
+import fs from 'node:fs';
+import { uploadImage, generateMarkdown, formatFileSize } from '../src/index.js';
+
+// Create a minimal 1x1 PNG image (red pixel)
+// This is a valid PNG file that can be uploaded
+const PNG_HEADER = Buffer.from([
+  0x89,
+  0x50,
+  0x4e,
+  0x47,
+  0x0d,
+  0x0a,
+  0x1a,
+  0x0a, // PNG signature
+  0x00,
+  0x00,
+  0x00,
+  0x0d, // IHDR chunk length
+  0x49,
+  0x48,
+  0x44,
+  0x52, // "IHDR"
+  0x00,
+  0x00,
+  0x00,
+  0x01, // width: 1
+  0x00,
+  0x00,
+  0x00,
+  0x01, // height: 1
+  0x08,
+  0x02, // bit depth 8, color type 2 (RGB)
+  0x00,
+  0x00,
+  0x00, // compression, filter, interlace
+  0x90,
+  0x77,
+  0x53,
+  0xde, // CRC
+  0x00,
+  0x00,
+  0x00,
+  0x0c, // IDAT chunk length
+  0x49,
+  0x44,
+  0x41,
+  0x54, // "IDAT"
+  0x08,
+  0xd7,
+  0x63,
+  0xf8,
+  0xcf,
+  0xc0,
+  0x00,
+  0x00, // zlib compressed data
+  0x00,
+  0x03,
+  0x00,
+  0x01, // ... (red pixel)
+  0xa9,
+  0x7e,
+  0xc7,
+  0x8f, // CRC
+  0x00,
+  0x00,
+  0x00,
+  0x00, // IEND chunk length
+  0x49,
+  0x45,
+  0x4e,
+  0x44, // "IEND"
+  0xae,
+  0x42,
+  0x60,
+  0x82, // CRC
+]);
+
+const testImagePath = '/tmp/test-upload.png';
+
+async function main() {
+  console.log('Creating test image...');
+  fs.writeFileSync(testImagePath, PNG_HEADER);
+  console.log(`Test image created: ${testImagePath}`);
+
+  console.log('');
+  console.log('Testing upload to link-foundation/gh-upload-image...');
+
+  try {
+    const result = await uploadImage({
+      filePath: testImagePath,
+      repository: 'link-foundation/gh-upload-image',
+      verbose: true,
+    });
+
+    console.log('');
+    console.log('Upload successful!');
+    console.log(`URL: ${result.url}`);
+    console.log(`Asset ID: ${result.assetId}`);
+    console.log(`File name: ${result.fileName}`);
+    console.log(`File size: ${formatFileSize(result.fileSize)}`);
+    console.log(`MIME type: ${result.mimeType}`);
+    console.log('');
+    console.log('Markdown:');
+    console.log(generateMarkdown(result, 'Test Image'));
+  } catch (error) {
+    console.error('');
+    console.error('Error:', error.message);
+    console.error(error.stack);
+    process.exit(1);
+  } finally {
+    // Cleanup
+    if (fs.existsSync(testImagePath)) {
+      fs.unlinkSync(testImagePath);
+    }
+  }
+}
+
+main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
-  "name": "my-package",
-  "version": "0.2.2",
+  "name": "gh-upload-image",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-package",
-      "version": "0.2.2",
+      "name": "gh-upload-image",
+      "version": "0.1.0",
       "license": "Unlicense",
+      "bin": {
+        "gh-upload-image": "src/cli.js"
+      },
       "devDependencies": {
         "@changesets/cli": "^2.29.7",
         "eslint": "^9.38.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "my-package",
-  "version": "0.2.2",
-  "description": "A JavaScript/TypeScript package template for AI-driven development",
+  "name": "gh-upload-image",
+  "version": "0.1.0",
+  "description": "Upload images to GitHub using the undocumented /upload/policies/assets endpoint. Works with both public and private repositories.",
   "type": "module",
   "main": "src/index.js",
   "types": "src/index.d.ts",
+  "bin": {
+    "gh-upload-image": "./src/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./src/index.d.ts",
@@ -26,16 +29,22 @@
     "changeset:status": "changeset status --since=origin/main"
   },
   "keywords": [
-    "template",
-    "javascript",
-    "typescript",
-    "ai-driven"
+    "github",
+    "image",
+    "upload",
+    "cdn",
+    "markdown",
+    "issues",
+    "pull-requests",
+    "comments",
+    "attachments",
+    "cli"
   ],
   "author": "",
   "license": "Unlicense",
   "repository": {
     "type": "git",
-    "url": "https://github.com/link-foundation/js-ai-driven-development-pipeline-template"
+    "url": "https://github.com/link-foundation/gh-upload-image"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/scripts/validate-changeset.mjs
+++ b/scripts/validate-changeset.mjs
@@ -16,8 +16,8 @@ import { execSync } from 'child_process';
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { join } from 'path';
 
-// TODO: Update this to match your package name in package.json
-const PACKAGE_NAME = 'my-package';
+// Package name from package.json
+const PACKAGE_NAME = 'gh-upload-image';
 const CHANGESET_DIR = '.changeset';
 
 /**

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+/**
+ * gh-upload-image CLI
+ *
+ * Command-line interface for uploading images to GitHub
+ */
+
+import {
+  uploadImage,
+  generateMarkdown,
+  getFileSize,
+  formatFileSize,
+  fileExists,
+  ALLOWED_EXTENSIONS,
+} from './index.js';
+
+// Flag mappings for boolean options
+const BOOLEAN_FLAGS = {
+  '-h': 'help',
+  '--help': 'help',
+  '-V': 'version',
+  '--version': 'version',
+  '-v': 'verbose',
+  '--verbose': 'verbose',
+  '-d': 'dryMode',
+  '--dry': 'dryMode',
+  '--dry-mode': 'dryMode',
+  '-m': 'markdown',
+  '--markdown': 'markdown',
+};
+
+// Flag mappings for options that take values
+const VALUE_FLAGS = {
+  '-a': 'altText',
+  '--alt': 'altText',
+  '-r': 'repository',
+  '--repository': 'repository',
+  '--repo': 'repository',
+};
+
+/**
+ * Parse command-line arguments
+ * @param {string[]} args - Command-line arguments
+ * @returns {Object} Parsed options
+ */
+function parseArgs(args) {
+  const options = {
+    filePath: null,
+    repository: null,
+    verbose: false,
+    dryMode: false,
+    markdown: false,
+    altText: null,
+    help: false,
+    version: false,
+  };
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (BOOLEAN_FLAGS[arg]) {
+      options[BOOLEAN_FLAGS[arg]] = true;
+    } else if (VALUE_FLAGS[arg]) {
+      i++;
+      options[VALUE_FLAGS[arg]] = args[i];
+    } else if (!arg.startsWith('-') && !options.filePath) {
+      options.filePath = arg;
+    }
+
+    i++;
+  }
+
+  return options;
+}
+
+/**
+ * Show help message
+ */
+function showHelp() {
+  console.log(`
+gh-upload-image - Upload images to GitHub
+
+USAGE:
+  gh-upload-image <image-file> -r <owner/repo> [options]
+
+ARGUMENTS:
+  <image-file>           Path to the image file to upload
+
+OPTIONS:
+  -r, --repo <repo>      Repository in "owner/repo" format (required)
+  -m, --markdown         Output markdown format
+  -a, --alt <text>       Alt text for markdown output
+  -d, --dry, --dry-mode  Dry run mode - show what would be done
+  -v, --verbose          Enable verbose output
+  -h, --help             Show this help message
+  -V, --version          Show version number
+
+SUPPORTED FILE TYPES:
+  ${ALLOWED_EXTENSIONS.join(', ')}
+
+EXAMPLES:
+  # Upload an image to a repository
+  gh-upload-image screenshot.png -r owner/repo
+
+  # Get markdown output
+  gh-upload-image diagram.png -r owner/repo --markdown
+
+  # With custom alt text
+  gh-upload-image photo.jpg -r owner/repo -m -a "My Photo"
+
+  # Dry run mode
+  gh-upload-image image.gif -r owner/repo --dry
+
+AUTHENTICATION:
+  Uses the GitHub CLI (gh) for authentication.
+  Make sure you are logged in with: gh auth login
+
+NOTES:
+  - Images are uploaded to GitHub's CDN and can be used in issues,
+    pull requests, comments, and markdown files.
+  - Both public and private repositories are supported.
+  - The uploaded URL format: https://github.com/user-attachments/assets/<id>
+`);
+}
+
+/**
+ * Show version
+ */
+function showVersion() {
+  console.log('0.1.0');
+}
+
+/**
+ * Main CLI function
+ */
+async function main() {
+  const args = process.argv.slice(2);
+  const options = parseArgs(args);
+
+  if (options.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  if (options.version) {
+    showVersion();
+    process.exit(0);
+  }
+
+  // Validate required arguments
+  if (!options.filePath) {
+    console.error('Error: Image file path is required');
+    console.error('Usage: gh-upload-image <image-file> -r <owner/repo>');
+    console.error('Run "gh-upload-image --help" for more information');
+    process.exit(1);
+  }
+
+  if (!options.repository) {
+    console.error('Error: Repository is required');
+    console.error('Usage: gh-upload-image <image-file> -r <owner/repo>');
+    console.error('Run "gh-upload-image --help" for more information');
+    process.exit(1);
+  }
+
+  try {
+    // Show file info
+    if (fileExists(options.filePath)) {
+      const fileSize = getFileSize(options.filePath);
+      const dryModePrefix = options.dryMode ? '[DRY] ' : '';
+
+      if (options.verbose) {
+        console.log(`File: ${options.filePath}`);
+        console.log(`Size: ${formatFileSize(fileSize)}`);
+        console.log(`Repository: ${options.repository}`);
+        console.log('');
+      }
+
+      console.log(
+        `${dryModePrefix}Uploading ${formatFileSize(fileSize)} to ${options.repository}...`
+      );
+    }
+
+    // Upload the image
+    const result = await uploadImage({
+      filePath: options.filePath,
+      repository: options.repository,
+      verbose: options.verbose,
+      dryMode: options.dryMode,
+    });
+
+    // Display results
+    if (result.dryMode) {
+      console.log('DRY MODE: Would upload image');
+      console.log(`  File: ${result.fileName}`);
+      console.log(`  Size: ${formatFileSize(result.fileSize)}`);
+      console.log(`  Repository: ${result.repository}`);
+    } else {
+      console.log('Upload successful!');
+
+      if (options.markdown) {
+        const markdown = generateMarkdown(result, options.altText);
+        console.log('');
+        console.log('Markdown:');
+        console.log(markdown);
+      } else {
+        console.log(`URL: ${result.url}`);
+      }
+
+      if (options.verbose) {
+        console.log('');
+        console.log('Details:');
+        console.log(`  Asset ID: ${result.assetId}`);
+        console.log(`  File name: ${result.fileName}`);
+        console.log(`  File size: ${formatFileSize(result.fileSize)}`);
+        console.log(`  MIME type: ${result.mimeType}`);
+        console.log(`  Repository: ${result.repository}`);
+      }
+    }
+
+    process.exit(0);
+  } catch (error) {
+    console.error('');
+    console.error('Error:', error.message);
+
+    if (options.verbose && error.stack) {
+      console.error('');
+      console.error('Stack trace:');
+      console.error(error.stack);
+    }
+
+    process.exit(1);
+  }
+}
+
+// Run the CLI
+main();

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,27 +1,226 @@
 /**
- * Example module type definitions
- * Replace this with your actual type definitions
+ * gh-upload-image - TypeScript definitions
+ *
+ * Upload images to GitHub using the undocumented /upload/policies/assets endpoint.
  */
 
 /**
- * Adds two numbers
- * @param a - First number
- * @param b - Second number
- * @returns Sum of a and b
+ * Allowed file extensions for GitHub image upload
  */
-export declare const add: (a: number, b: number) => number;
+export declare const ALLOWED_EXTENSIONS: readonly string[];
 
 /**
- * Multiplies two numbers
- * @param a - First number
- * @param b - Second number
- * @returns Product of a and b
+ * Options for uploading an image
  */
-export declare const multiply: (a: number, b: number) => number;
+export interface UploadImageOptions {
+  /**
+   * Path to the image file to upload
+   */
+  filePath: string;
+
+  /**
+   * Repository in "owner/repo" format or GitHub URL
+   */
+  repository: string;
+
+  /**
+   * Enable verbose logging
+   * @default false
+   */
+  verbose?: boolean;
+
+  /**
+   * Dry run mode - show what would be done without uploading
+   * @default false
+   */
+  dryMode?: boolean;
+
+  /**
+   * Custom logger object
+   * @default console
+   */
+  logger?: {
+    log: (message: string) => void;
+    warn?: (message: string) => void;
+    error?: (message: string) => void;
+    debug?: (message: string) => void;
+  };
+}
 
 /**
- * Delays execution for specified milliseconds
- * @param ms - Milliseconds to wait
- * @returns Promise that resolves after the delay
+ * Result of an image upload
  */
-export declare const delay: (ms: number) => Promise<void>;
+export interface UploadResult {
+  /**
+   * The URL of the uploaded image on GitHub's CDN
+   */
+  url: string;
+
+  /**
+   * The unique asset ID
+   */
+  assetId: string | null;
+
+  /**
+   * The original file name
+   */
+  fileName: string;
+
+  /**
+   * The file size in bytes
+   */
+  fileSize: number;
+
+  /**
+   * The MIME type of the file
+   */
+  mimeType: string;
+
+  /**
+   * The repository where the image was uploaded
+   */
+  repository: string;
+
+  /**
+   * Whether this was a dry run
+   */
+  dryMode: boolean;
+}
+
+/**
+ * Parsed repository information
+ */
+export interface ParsedRepository {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Upload an image to GitHub
+ *
+ * @param options - Upload options
+ * @returns Promise resolving to the upload result
+ *
+ * @example
+ * ```javascript
+ * import { uploadImage } from 'gh-upload-image';
+ *
+ * const result = await uploadImage({
+ *   filePath: './screenshot.png',
+ *   repository: 'owner/repo',
+ * });
+ *
+ * console.log(result.url);
+ * // https://github.com/user-attachments/assets/abc123...
+ * ```
+ */
+export declare function uploadImage(
+  options: UploadImageOptions
+): Promise<UploadResult>;
+
+/**
+ * Generate markdown for an uploaded image
+ *
+ * @param result - The upload result from uploadImage
+ * @param altText - Alternative text for the image (optional)
+ * @returns Markdown string for embedding the image
+ *
+ * @example
+ * ```javascript
+ * const markdown = generateMarkdown(result, 'Screenshot');
+ * // ![Screenshot](https://github.com/user-attachments/assets/abc123...)
+ * ```
+ */
+export declare function generateMarkdown(
+  result: UploadResult,
+  altText?: string
+): string;
+
+/**
+ * Check if a file exists
+ *
+ * @param filePath - Path to the file
+ * @returns True if the file exists and is a file
+ */
+export declare function fileExists(filePath: string): boolean;
+
+/**
+ * Get file size in bytes
+ *
+ * @param filePath - Path to the file
+ * @returns File size in bytes
+ */
+export declare function getFileSize(filePath: string): number;
+
+/**
+ * Format file size in human readable format
+ *
+ * @param bytes - File size in bytes
+ * @returns Formatted string (e.g., "1.5 MB")
+ */
+export declare function formatFileSize(bytes: number): string;
+
+/**
+ * Get MIME type for a file based on its extension
+ *
+ * @param filePath - Path to the file
+ * @returns MIME type string
+ */
+export declare function getMimeType(filePath: string): string;
+
+/**
+ * Check if a file extension is allowed for upload
+ *
+ * @param filePath - Path to the file
+ * @returns True if the extension is allowed
+ */
+export declare function isExtensionAllowed(filePath: string): boolean;
+
+/**
+ * Parse a repository string into owner and repo
+ *
+ * @param repository - Repository in "owner/repo" format or GitHub URL
+ * @returns Parsed repository with owner and repo
+ * @throws Error if the format is invalid
+ */
+export declare function parseRepository(repository: string): ParsedRepository;
+
+/**
+ * Get the GitHub token from gh CLI
+ *
+ * @returns Promise resolving to the GitHub token
+ * @throws Error if not logged in or gh CLI is not available
+ */
+export declare function getGitHubToken(): Promise<string>;
+
+/**
+ * Get repository ID from GitHub API
+ *
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @returns Promise resolving to the repository ID
+ * @throws Error if repository not found or access denied
+ */
+export declare function getRepositoryId(
+  owner: string,
+  repo: string
+): Promise<number>;
+
+/**
+ * Default export with all functions
+ */
+declare const _default: {
+  uploadImage: typeof uploadImage;
+  generateMarkdown: typeof generateMarkdown;
+  fileExists: typeof fileExists;
+  getFileSize: typeof getFileSize;
+  formatFileSize: typeof formatFileSize;
+  getMimeType: typeof getMimeType;
+  isExtensionAllowed: typeof isExtensionAllowed;
+  parseRepository: typeof parseRepository;
+  getGitHubToken: typeof getGitHubToken;
+  getRepositoryId: typeof getRepositoryId;
+  ALLOWED_EXTENSIONS: typeof ALLOWED_EXTENSIONS;
+};
+
+export default _default;

--- a/src/index.js
+++ b/src/index.js
@@ -1,28 +1,438 @@
-/**
- * Example module entry point
- * Replace this with your actual implementation
- */
+#!/usr/bin/env node
 
 /**
- * Example function that adds two numbers
- * @param {number} a - First number
- * @param {number} b - Second number
- * @returns {number} Sum of a and b
+ * gh-upload-image - Core library for uploading images to GitHub
+ *
+ * This library provides functionality to upload images to GitHub using the
+ * undocumented /upload/policies/assets endpoint. The uploaded images are
+ * stored on GitHub's CDN (private-user-images.githubusercontent.com) and
+ * can be used in issues, pull requests, comments, and markdown files.
  */
-export const add = (a, b) => a + b;
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
 
 /**
- * Example function that multiplies two numbers
- * @param {number} a - First number
- * @param {number} b - Second number
- * @returns {number} Product of a and b
+ * Allowed file types for GitHub image upload
  */
-export const multiply = (a, b) => a * b;
+export const ALLOWED_EXTENSIONS = [
+  '.gif',
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.docx',
+  '.gz',
+  '.log',
+  '.pdf',
+  '.pptx',
+  '.txt',
+  '.xlsx',
+  '.zip',
+  '.webp',
+  '.svg',
+  '.mp4',
+  '.mov',
+];
 
 /**
- * Example async function
- * @param {number} ms - Milliseconds to wait
+ * MIME types mapping for common file extensions
+ */
+const MIME_TYPES = {
+  '.gif': 'image/gif',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.pdf': 'application/pdf',
+  '.docx':
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.pptx':
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.txt': 'text/plain',
+  '.log': 'text/plain',
+  '.gz': 'application/gzip',
+  '.zip': 'application/zip',
+  '.mp4': 'video/mp4',
+  '.mov': 'video/quicktime',
+};
+
+/**
+ * Default logger implementation with configurable log levels
+ * @param {Object} options - Logger options
+ * @param {boolean} options.verbose - Whether to enable verbose logging
+ * @param {Object} options.logger - Custom logger object (default: console)
+ * @returns {Object} Logger object with log methods
+ */
+function createDefaultLogger(options = {}) {
+  const { verbose = false, logger = console } = options;
+  return {
+    debug: verbose ? (msg) => logger.log(msg) : () => {},
+    info: (msg) => logger.log(msg),
+    warn: (msg) => (logger.warn || logger.log)(msg),
+    error: (msg) => (logger.error || logger.log)(msg),
+  };
+}
+
+/**
+ * Check if a file exists
+ * @param {string} filePath - Path to the file
+ * @returns {boolean} True if the file exists
+ */
+export function fileExists(filePath) {
+  try {
+    return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get file size in bytes
+ * @param {string} filePath - Path to the file
+ * @returns {number} File size in bytes
+ */
+export function getFileSize(filePath) {
+  return fs.statSync(filePath).size;
+}
+
+/**
+ * Format file size in human readable format
+ * @param {number} bytes - File size in bytes
+ * @returns {string} Formatted file size
+ */
+export function formatFileSize(bytes) {
+  if (bytes === 0) {
+    return '0 B';
+  }
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const base = 1024;
+  const unitIndex = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(base)),
+    units.length - 1
+  );
+  const size = bytes / Math.pow(base, unitIndex);
+  if (unitIndex === 0) {
+    return `${size} ${units[unitIndex]}`;
+  }
+  return `${size.toFixed(2)} ${units[unitIndex]}`;
+}
+
+/**
+ * Get MIME type for a file extension
+ * @param {string} filePath - Path to the file
+ * @returns {string} MIME type
+ */
+export function getMimeType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return MIME_TYPES[ext] || 'application/octet-stream';
+}
+
+/**
+ * Check if file extension is allowed
+ * @param {string} filePath - Path to the file
+ * @returns {boolean} True if the file extension is allowed
+ */
+export function isExtensionAllowed(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return ALLOWED_EXTENSIONS.includes(ext);
+}
+
+/**
+ * Execute a command and return its output
+ * @param {string} command - Command to execute
+ * @param {string[]} args - Command arguments
+ * @returns {Promise<string>} Command output
+ */
+function execCommand(command, args) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        const errorMsg =
+          stderr.trim() || `Command failed with exit code ${code}`;
+        reject(new Error(errorMsg));
+      }
+    });
+
+    proc.on('error', (err) => {
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Get the GitHub token from gh CLI
+ * @returns {Promise<string>} GitHub token
+ */
+export async function getGitHubToken() {
+  try {
+    const token = await execCommand('gh', ['auth', 'token']);
+    return token;
+  } catch (error) {
+    throw new Error(
+      `Failed to get GitHub token. Make sure you are logged in with "gh auth login". ${error.message}`
+    );
+  }
+}
+
+/**
+ * Get repository ID from GitHub API
+ * @param {string} owner - Repository owner
+ * @param {string} repo - Repository name
+ * @returns {Promise<number>} Repository ID
+ */
+export async function getRepositoryId(owner, repo) {
+  try {
+    const result = await execCommand('gh', [
+      'api',
+      `repos/${owner}/${repo}`,
+      '--jq',
+      '.id',
+    ]);
+    return parseInt(result, 10);
+  } catch (error) {
+    throw new Error(
+      `Failed to get repository ID for ${owner}/${repo}. Make sure the repository exists and you have access. ${error.message}`
+    );
+  }
+}
+
+/**
+ * Parse repository string into owner and repo
+ * @param {string} repository - Repository in format "owner/repo" or URL
+ * @returns {{owner: string, repo: string}} Owner and repo
+ */
+export function parseRepository(repository) {
+  // Handle GitHub URLs
+  const urlMatch = repository.match(/github\.com[/:]([^/]+)\/([^/.]+)/);
+  if (urlMatch) {
+    return { owner: urlMatch[1], repo: urlMatch[2] };
+  }
+
+  // Handle owner/repo format
+  const parts = repository.split('/');
+  if (parts.length === 2) {
+    return { owner: parts[0], repo: parts[1] };
+  }
+
+  throw new Error(
+    `Invalid repository format: "${repository}". Use "owner/repo" format.`
+  );
+}
+
+/**
+ * Validate upload options and file
+ * @param {string} filePath - Path to the file
+ * @param {string} repository - Repository in "owner/repo" format
+ */
+function validateUploadInput(filePath, repository) {
+  if (!filePath) {
+    throw new Error('filePath is required in options');
+  }
+  if (!repository) {
+    throw new Error('repository is required in options');
+  }
+  if (!fileExists(filePath)) {
+    throw new Error(`File does not exist: ${filePath}`);
+  }
+  if (!isExtensionAllowed(filePath)) {
+    const ext = path.extname(filePath).toLowerCase();
+    throw new Error(
+      `File extension "${ext}" is not allowed. Allowed extensions: ${ALLOWED_EXTENSIONS.join(', ')}`
+    );
+  }
+}
+
+/**
+ * Request upload policy from GitHub
+ * @param {Object} params - Policy request parameters
+ * @returns {Promise<Object>} Upload policy
+ */
+async function requestUploadPolicy(params) {
+  const { token, repositoryId, fileName, fileSize, mimeType } = params;
+
+  const policyParams = new URLSearchParams();
+  policyParams.append('name', fileName);
+  policyParams.append('size', fileSize.toString());
+  policyParams.append('content_type', mimeType);
+  policyParams.append('repository_id', repositoryId.toString());
+
+  const response = await fetch('https://github.com/upload/policies/assets', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `token ${token}`,
+      'User-Agent': 'gh-upload-image/0.1.0',
+    },
+    body: policyParams.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Failed to get upload policy: ${response.status} ${response.statusText}. ${errorText}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Upload file to storage using the policy
+ * @param {Object} params - Upload parameters
  * @returns {Promise<void>}
  */
-export const delay = (ms) =>
-  new Promise((resolve) => globalThis.setTimeout(resolve, ms));
+async function uploadFileToStorage(params) {
+  const { policy, filePath, fileName, mimeType } = params;
+
+  const fileBuffer = fs.readFileSync(filePath);
+  const formData = new FormData();
+
+  for (const [key, value] of Object.entries(policy.form)) {
+    formData.append(key, value);
+  }
+  formData.append('file', new Blob([fileBuffer], { type: mimeType }), fileName);
+
+  const response = await fetch(policy.upload_url, {
+    method: 'POST',
+    body: formData,
+  });
+
+  const isSuccess =
+    response.ok || response.status === 201 || response.status === 204;
+
+  if (!isSuccess) {
+    const errorText = await response.text();
+    throw new Error(
+      `Failed to upload file: ${response.status} ${response.statusText}. ${errorText}`
+    );
+  }
+}
+
+/**
+ * Upload an image to GitHub
+ * @param {Object} options - Upload options
+ * @param {string} options.filePath - Path to the image file
+ * @param {string} options.repository - Repository in "owner/repo" format
+ * @param {boolean} options.verbose - Enable verbose logging
+ * @param {boolean} options.dryMode - Dry run mode
+ * @param {Object} options.logger - Custom logger
+ * @returns {Promise<Object>} Upload result with URL and asset ID
+ */
+export async function uploadImage(options = {}) {
+  const {
+    filePath,
+    repository,
+    verbose = false,
+    dryMode = false,
+    logger = console,
+  } = options;
+
+  validateUploadInput(filePath, repository);
+
+  const log = createDefaultLogger({ verbose, logger });
+  const { owner, repo } = parseRepository(repository);
+  const fileName = path.basename(filePath);
+  const fileSize = getFileSize(filePath);
+  const mimeType = getMimeType(filePath);
+
+  log.debug(`Uploading: ${fileName}`);
+  log.debug(`File size: ${formatFileSize(fileSize)}`);
+  log.debug(`MIME type: ${mimeType}`);
+  log.debug(`Repository: ${owner}/${repo}`);
+
+  if (dryMode) {
+    return {
+      url: `[DRY MODE] Would upload ${fileName} to ${owner}/${repo}`,
+      assetId: null,
+      fileName,
+      fileSize,
+      mimeType,
+      repository: `${owner}/${repo}`,
+      dryMode: true,
+    };
+  }
+
+  log.debug('Getting GitHub token...');
+  const token = await getGitHubToken();
+
+  log.debug(`Getting repository ID for ${owner}/${repo}...`);
+  const repositoryId = await getRepositoryId(owner, repo);
+  log.debug(`Repository ID: ${repositoryId}`);
+
+  log.debug('Requesting upload policy...');
+  const policy = await requestUploadPolicy({
+    token,
+    repositoryId,
+    fileName,
+    fileSize,
+    mimeType,
+  });
+  log.debug('Upload policy received');
+  log.debug(`Upload URL: ${policy.upload_url}`);
+  log.debug(`Asset ID: ${policy.asset?.id}`);
+
+  log.debug('Uploading file to storage...');
+  await uploadFileToStorage({ policy, filePath, fileName, mimeType });
+  log.debug('File uploaded successfully');
+
+  const assetId = policy.asset?.id;
+  const url = `https://github.com/user-attachments/assets/${assetId}`;
+  log.debug(`Asset URL: ${url}`);
+
+  return {
+    url,
+    assetId,
+    fileName,
+    fileSize,
+    mimeType,
+    repository: `${owner}/${repo}`,
+    dryMode: false,
+  };
+}
+
+/**
+ * Generate markdown for an uploaded image
+ * @param {Object} result - Upload result from uploadImage
+ * @param {string} altText - Alternative text for the image
+ * @returns {string} Markdown string
+ */
+export function generateMarkdown(result, altText) {
+  const alt = altText || result.fileName || 'image';
+  return `![${alt}](${result.url})`;
+}
+
+// Default export with all functions
+export default {
+  uploadImage,
+  generateMarkdown,
+  fileExists,
+  getFileSize,
+  formatFileSize,
+  getMimeType,
+  isExtensionAllowed,
+  parseRepository,
+  getGitHubToken,
+  getRepositoryId,
+  ALLOWED_EXTENSIONS,
+};

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,35 +1,217 @@
 /**
- * Example test file using test-anywhere
+ * Tests for gh-upload-image
  * Works with Node.js, Bun, and Deno
  */
 
 import { describe, it, expect } from 'test-anywhere';
-import { add, multiply } from '../src/index.js';
+import {
+  fileExists,
+  getFileSize,
+  formatFileSize,
+  getMimeType,
+  isExtensionAllowed,
+  parseRepository,
+  generateMarkdown,
+  ALLOWED_EXTENSIONS,
+} from '../src/index.js';
 
-describe('add function', () => {
-  it('should add two positive numbers', () => {
-    expect(add(2, 3)).toBe(5);
+describe('fileExists', () => {
+  it('should return true for existing files', () => {
+    expect(fileExists('./package.json')).toBe(true);
   });
 
-  it('should add negative numbers', () => {
-    expect(add(-1, -2)).toBe(-3);
+  it('should return false for non-existing files', () => {
+    expect(fileExists('./non-existent-file.txt')).toBe(false);
   });
 
-  it('should add zero', () => {
-    expect(add(5, 0)).toBe(5);
+  it('should return false for directories', () => {
+    expect(fileExists('./src')).toBe(false);
   });
 });
 
-describe('multiply function', () => {
-  it('should multiply two positive numbers', () => {
-    expect(multiply(2, 3)).toBe(6);
+describe('getFileSize', () => {
+  it('should return file size in bytes', () => {
+    const size = getFileSize('./package.json');
+    expect(typeof size).toBe('number');
+    expect(size).toBeGreaterThan(0);
+  });
+});
+
+describe('formatFileSize', () => {
+  it('should format 0 bytes', () => {
+    expect(formatFileSize(0)).toBe('0 B');
   });
 
-  it('should multiply by zero', () => {
-    expect(multiply(5, 0)).toBe(0);
+  it('should format bytes', () => {
+    expect(formatFileSize(500)).toBe('500 B');
   });
 
-  it('should multiply negative numbers', () => {
-    expect(multiply(-2, 3)).toBe(-6);
+  it('should format kilobytes', () => {
+    expect(formatFileSize(1024)).toBe('1.00 KB');
+    expect(formatFileSize(2048)).toBe('2.00 KB');
+  });
+
+  it('should format megabytes', () => {
+    expect(formatFileSize(1024 * 1024)).toBe('1.00 MB');
+    expect(formatFileSize(5.5 * 1024 * 1024)).toBe('5.50 MB');
+  });
+
+  it('should format gigabytes', () => {
+    expect(formatFileSize(1024 * 1024 * 1024)).toBe('1.00 GB');
+  });
+});
+
+describe('getMimeType', () => {
+  it('should return correct MIME type for images', () => {
+    expect(getMimeType('image.png')).toBe('image/png');
+    expect(getMimeType('image.jpg')).toBe('image/jpeg');
+    expect(getMimeType('image.jpeg')).toBe('image/jpeg');
+    expect(getMimeType('image.gif')).toBe('image/gif');
+    expect(getMimeType('image.webp')).toBe('image/webp');
+    expect(getMimeType('image.svg')).toBe('image/svg+xml');
+  });
+
+  it('should return correct MIME type for documents', () => {
+    expect(getMimeType('document.pdf')).toBe('application/pdf');
+    expect(getMimeType('file.txt')).toBe('text/plain');
+    expect(getMimeType('file.log')).toBe('text/plain');
+  });
+
+  it('should return correct MIME type for archives', () => {
+    expect(getMimeType('archive.zip')).toBe('application/zip');
+    expect(getMimeType('archive.gz')).toBe('application/gzip');
+  });
+
+  it('should return correct MIME type for videos', () => {
+    expect(getMimeType('video.mp4')).toBe('video/mp4');
+    expect(getMimeType('video.mov')).toBe('video/quicktime');
+  });
+
+  it('should be case-insensitive', () => {
+    expect(getMimeType('image.PNG')).toBe('image/png');
+    expect(getMimeType('image.JPG')).toBe('image/jpeg');
+  });
+
+  it('should return octet-stream for unknown types', () => {
+    expect(getMimeType('file.unknown')).toBe('application/octet-stream');
+  });
+});
+
+describe('isExtensionAllowed', () => {
+  it('should allow image extensions', () => {
+    expect(isExtensionAllowed('image.png')).toBe(true);
+    expect(isExtensionAllowed('image.jpg')).toBe(true);
+    expect(isExtensionAllowed('image.jpeg')).toBe(true);
+    expect(isExtensionAllowed('image.gif')).toBe(true);
+    expect(isExtensionAllowed('image.webp')).toBe(true);
+    expect(isExtensionAllowed('image.svg')).toBe(true);
+  });
+
+  it('should allow document extensions', () => {
+    expect(isExtensionAllowed('document.pdf')).toBe(true);
+    expect(isExtensionAllowed('document.docx')).toBe(true);
+    expect(isExtensionAllowed('document.pptx')).toBe(true);
+    expect(isExtensionAllowed('document.xlsx')).toBe(true);
+    expect(isExtensionAllowed('file.txt')).toBe(true);
+    expect(isExtensionAllowed('file.log')).toBe(true);
+  });
+
+  it('should allow archive extensions', () => {
+    expect(isExtensionAllowed('archive.zip')).toBe(true);
+    expect(isExtensionAllowed('archive.gz')).toBe(true);
+  });
+
+  it('should allow video extensions', () => {
+    expect(isExtensionAllowed('video.mp4')).toBe(true);
+    expect(isExtensionAllowed('video.mov')).toBe(true);
+  });
+
+  it('should reject disallowed extensions', () => {
+    expect(isExtensionAllowed('file.exe')).toBe(false);
+    expect(isExtensionAllowed('file.js')).toBe(false);
+    expect(isExtensionAllowed('file.html')).toBe(false);
+    expect(isExtensionAllowed('file.sh')).toBe(false);
+  });
+
+  it('should be case-insensitive', () => {
+    expect(isExtensionAllowed('image.PNG')).toBe(true);
+    expect(isExtensionAllowed('image.JPG')).toBe(true);
+  });
+});
+
+describe('parseRepository', () => {
+  it('should parse owner/repo format', () => {
+    const result = parseRepository('owner/repo');
+    expect(result.owner).toBe('owner');
+    expect(result.repo).toBe('repo');
+  });
+
+  it('should parse GitHub HTTPS URL', () => {
+    const result = parseRepository('https://github.com/owner/repo');
+    expect(result.owner).toBe('owner');
+    expect(result.repo).toBe('repo');
+  });
+
+  it('should parse GitHub HTTPS URL with .git suffix', () => {
+    const result = parseRepository('https://github.com/owner/repo.git');
+    expect(result.owner).toBe('owner');
+    expect(result.repo).toBe('repo');
+  });
+
+  it('should parse GitHub SSH URL', () => {
+    const result = parseRepository('git@github.com:owner/repo.git');
+    expect(result.owner).toBe('owner');
+    expect(result.repo).toBe('repo');
+  });
+
+  it('should throw error for invalid format', () => {
+    expect(() => parseRepository('invalid')).toThrow();
+    expect(() => parseRepository('')).toThrow();
+    expect(() => parseRepository('a/b/c')).toThrow();
+  });
+});
+
+describe('generateMarkdown', () => {
+  const mockResult = {
+    url: 'https://github.com/user-attachments/assets/abc123',
+    fileName: 'test-image.png',
+  };
+
+  it('should generate markdown with alt text', () => {
+    const markdown = generateMarkdown(mockResult, 'My Image');
+    expect(markdown).toBe(
+      '![My Image](https://github.com/user-attachments/assets/abc123)'
+    );
+  });
+
+  it('should use filename as alt text when not provided', () => {
+    const markdown = generateMarkdown(mockResult);
+    expect(markdown).toBe(
+      '![test-image.png](https://github.com/user-attachments/assets/abc123)'
+    );
+  });
+
+  it('should use "image" as fallback alt text', () => {
+    const result = { url: 'https://example.com/image.png' };
+    const markdown = generateMarkdown(result);
+    expect(markdown).toBe('![image](https://example.com/image.png)');
+  });
+});
+
+describe('ALLOWED_EXTENSIONS', () => {
+  it('should be an array of extensions', () => {
+    expect(Array.isArray(ALLOWED_EXTENSIONS)).toBe(true);
+  });
+
+  it('should contain common image extensions', () => {
+    expect(ALLOWED_EXTENSIONS).toContain('.png');
+    expect(ALLOWED_EXTENSIONS).toContain('.jpg');
+    expect(ALLOWED_EXTENSIONS).toContain('.jpeg');
+    expect(ALLOWED_EXTENSIONS).toContain('.gif');
+  });
+
+  it('should contain document extensions', () => {
+    expect(ALLOWED_EXTENSIONS).toContain('.pdf');
+    expect(ALLOWED_EXTENSIONS).toContain('.txt');
   });
 });


### PR DESCRIPTION
## Summary
- Implements gh-upload-image, a CLI and library for uploading images to GitHub using the undocumented `/upload/policies/assets` endpoint
- Uses GitHub CLI (`gh`) for authentication - no additional tokens required
- Supports images (PNG, JPG, GIF, WebP, SVG), videos (MP4, MOV), documents (PDF, DOCX, TXT), and archives (ZIP, GZ)

## Features
- **Core library** (`src/index.js`) with `uploadImage`, `generateMarkdown`, and utility functions
- **CLI interface** (`src/cli.js`) for command-line usage with markdown output support
- **TypeScript definitions** (`src/index.d.ts`) for full type support
- **Comprehensive tests** (32 passing tests) for all utility functions
- **Multi-runtime support** - works with Node.js, Bun, and Deno

## Usage Examples

### CLI
```bash
# Upload an image
gh-upload-image screenshot.png -r owner/repo

# Get markdown output
gh-upload-image diagram.png -r owner/repo --markdown

# Dry run
gh-upload-image image.gif -r owner/repo --dry
```

### Library
```javascript
import { uploadImage, generateMarkdown } from 'gh-upload-image';

const result = await uploadImage({
  filePath: './screenshot.png',
  repository: 'owner/repo',
});

console.log(generateMarkdown(result, 'Screenshot'));
// ![Screenshot](https://github.com/user-attachments/assets/abc123...)
```

## Test plan
- [x] All 32 unit tests pass
- [x] ESLint passes with no errors
- [x] Prettier formatting is correct
- [x] No code duplication detected
- [x] Example script runs successfully
- [ ] End-to-end upload test (requires working GitHub API authentication)

## Notes
This uses an undocumented GitHub API endpoint (`/upload/policies/assets`). GitHub may change or restrict access to this endpoint. The implementation follows patterns discovered in existing tools like [ghfileupl](https://github.com/maple3142/ghfileupl) and [VibeChannel](https://github.com/lucasygu/VibeChannel).

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)